### PR TITLE
Allow libcrange to build on OSX

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -3,14 +3,21 @@
 set -e
 set -x
 
-aclocal || exit 1
-libtoolize --force || exit 1
-autoheader || exit 1
-automake -a || exit 1
-autoconf || exit 1
-./configure --prefix=/usr || exit 1
-make || exit 1
-make install  || exit 1
+aclocal
+case "${OSTYPE}" in
+	darwin*)
+		glibtoolize --force
+		;;
+	*)
+		libtoolize --force
+		;;
+esac
+autoheader
+automake -a
+autoconf
+./configure --prefix=/usr
+make
+make install
 cd perl
-sh ./build || exit 1
+sh ./build
 

--- a/source/configure.ac
+++ b/source/configure.ac
@@ -90,7 +90,6 @@ AC_CHECK_PERL
 AC_CHECK_PCRE
 AC_CHECK_APR
 
-AC_CHECK_LIB([crypt], [crypt_r], [], [exit 1])
 AC_CHECK_LIB([m], [sin], [], [exit 1])
 AC_CHECK_LIB([pthread], [pthread_create], [], [exit 1])
 AC_CHECK_LIB([z], [zlibVersion], [], [exit 1])


### PR DESCRIPTION
I got these changes merged into ytoolshed/range, but it looks like this is the most active libcrange repo.

Where is the most official libcrange repo? There are a bunch.
