### PR TITLE
Added perl module that queries external range servers for clusters

### DIFF
--- a/root/var/libcrange/perl/LibrangeRemoteCluster.pm
+++ b/root/var/libcrange/perl/LibrangeRemoteCluster.pm
@@ -1,0 +1,22 @@
+package LibrangeRemoteCluster;
+
+use strict;
+use warnings;
+
+use Libcrange;
+use LWP::Simple;
+
+sub functions_provided {
+    return qw/cluster/;
+}
+
+sub cluster {
+    my ($rr, $range) = @_;
+
+    my $server = Libcrange::get_var($rr, "range_server");
+    $server = "range" unless $server;
+
+    return map { split /\n/, get("http://$server/range/list?%$_") } @$range;
+}
+
+1;


### PR DESCRIPTION
By default, libcrange doesn't seem to come with any module that queries range clusters from external servers. This simple Perl module fills that gap. Resolves to nothing if cluster def doesn't exist.
