### PR TITLE
Update doit.sh

### DIFF
--- a/source/doit.sh
+++ b/source/doit.sh
@@ -4,7 +4,6 @@ set -e
 set -x
 [ -n "$DESTDIR" ] || export DESTDIR=$HOME/prefix
 
-rm -rf $DESTDIR
 make clean || true # ignore failures
 
 aclocal


### PR DESCRIPTION
This can be a dangerous if a user uses this to install libcrange.

For example, if a user sets `$DESTDIR` to `/`, this will destroy their system. I'm...not saying that this happened to me or anything...
